### PR TITLE
meson: Allow C++/C exception stack traversal under MSVC ABI

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -12,6 +12,7 @@ project(
 		'warning_level=1',
 		'b_pie=true',
 		'b_lto=true',
+		'cpp_eh=s',
 	]
 )
 


### PR DESCRIPTION
This fixes the warning:

> libusb.h(1882): warning C5039: 'libusb_fill_bulk_transfer': pointer or
> reference to potentially throwing function passed to 'extern "C"'
> function under -EHc. Undefined behavior may occur if this function
> throws an exception.

Do note that an identical fix needs to be applied to consumers, currently Meson does not expose this.